### PR TITLE
Test and improve handling of anisotropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ANTSRegistration
+# ANTsRegistration
 
 [![Build Status](https://travis-ci.org/timholy/ANTSRegistration.jl.svg?branch=master)](https://travis-ci.org/timholy/ANTSRegistration.jl)
 
@@ -34,15 +34,12 @@ format. [NRRD](https://github.com/JuliaIO/NRRD.jl) is recommended. For
 those performing acquisition with Imagine, you can write out an
 [NRRD header](https://github.com/timholy/ImagineFormat.jl#converting-to-nrrd).
 
-If you are registering an image sequence stored in NRRD format, and you see an error like
-
-```sh
-Description: itk::ERROR: NrrdImageIO(0x2b62880): ReadImageInformation: nrrd's #independent axes (3) doesn't match dimension of space in which orientation is defined (2); not currently handled
-```
-
-the remedy appears to be to delete the `space dimension` and `space origin`
-fields from the header file. This is easier if you are using a
-detached header file (`.nhdr`).
+Unfortunately, [the NRRD format](http://teem.sourceforge.net/nrrd/format.html)
+lacks a file-validator, and a few aspects of the standard description seem
+to leave room for interpretation. If you encounter bugs, it is possible that
+Julia and ITK differ with respect to the implementation of the NRRD header.
+Try copying the command and running it the shell prompt, then report the error
+[here](https://github.com/JuliaIO/NRRD.jl/issues/new).
 
 ### Performing registration
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ opportunities for sub-pixel alignment at the finest scale.
 All parameters after `transform` have default values, so you only need
 to assign them if you need to control them more precisely.
 
+**Note on physical units**: if your images have anisotropic resolution,
+you should strongly consider using physical units for your smoothing.
+For example,
+
+```julia
+using Unitful: μm
+smooth=(50μm,5μm)
+```
+
+would be appropriate for a two-iteration stage.
+
 #### Top-level API
 
 To register the single image `moving` to the single image `fixed`, use

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.7
 Images 0.17
 FileIO
-NRRD
+NRRD 0.5
 Glob

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ Images 0.17
 FileIO
 NRRD 0.5
 Glob
+Unitful

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,7 +1,9 @@
 Images
+ImageMagick
 TestImages
 Rotations
 CoordinateTransformations
 MappedArrays
 FileIO
 NRRD
+Unitful

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,11 +138,12 @@ end
     img_rotated = warp(img, tfm)
     moving0 = img_rotated[75:320, 75:325]
     ps = (1u"μm", 2u"μm")
-    fixed = AxisArray(restrict(fixed0, 2), (:y, :x), ps)
-    moving = AxisArray(restrict(moving0, 2), (:y, :x), ps)
+    # If you don't trim the edges, the mixing with zeros "anchors" the image in place.
+    # see resolution of https://github.com/ANTsX/ANTs/issues/675
+    fixed = AxisArray(restrict(fixed0, 2)[:,2:end-1], (:y, :x), ps)
+    moving = AxisArray(restrict(moving0, 2)[:,2:end-1], (:y, :x), ps)
     stage = Stage(fixed, Global("Rigid"), MeanSquares(), (1,), (25u"μm",), (1000,))
     imgw0 = register(fixed0, moving0, stage)/255
     imgw = AxisArray(register(fixed, moving, stage), (:y, :x), ps)
-    # Currently broken, see https://github.com/ANTsX/ANTs/issues/675
-    @test_broken mean(mappedarray(diff2_0, fixed0, imgw0)) ≈ mean(mappedarray(diff2_0, fixed, imgw)) rtol=0.01
+    @test 1.01*mean(mappedarray(diff2_0, fixed0, imgw0)) >= mean(mappedarray(diff2_0, fixed, imgw))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,7 +140,7 @@ end
     ps = (1u"μm", 2u"μm")
     fixed = AxisArray(restrict(fixed0, 2), (:y, :x), ps)
     moving = AxisArray(restrict(moving0, 2), (:y, :x), ps)
-    stage = Stage(fixed, Global("Rigid"), MeanSquares(), (1,), (25,), (1000,))
+    stage = Stage(fixed, Global("Rigid"), MeanSquares(), (1,), (25u"μm",), (1000,))
     imgw0 = register(fixed0, moving0, stage)/255
     imgw = AxisArray(register(fixed, moving, stage), (:y, :x), ps)
     # Currently broken, see https://github.com/ANTsX/ANTs/issues/675


### PR DESCRIPTION
This adds a test to check that our usage is approximately invariant with respect to spatial scale. Understanding what's going on here was a bit of a saga, see https://github.com/ANTsX/ANTs/issues/675.