### PR TITLE
Add [compat]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,3 +13,12 @@ NRRD = "9bb6cfbd-7763-5393-b1b5-1c8e09872146"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[compat]
+FileIO = "1"
+Glob = "1"
+Images = "0.18, 0.19, 0.20, 0.21, 0.22, 0.23"
+NRRD = "0.6"
+Suppressor = "0.2"
+Unitful = "1"
+julia = "1"


### PR DESCRIPTION
I omitted BinaryProvider in anticipation that we'll soon have a JLL alternative (:tada:). At that point we should bump the Julia compat as well.